### PR TITLE
fix install

### DIFF
--- a/swig/setup.sh
+++ b/swig/setup.sh
@@ -18,5 +18,4 @@ if [ ! -d ThreadPool ]; then
 fi
 
 echo "Install decoders ..."
-# python3 setup.py install --num_processes 10
-python3 setup.py install --user --num_processes 10
+    python3 setup.py install --num_processes 10


### PR DESCRIPTION
It seems module install at /root/.local/lib can't find by tritonserver. We have to set the PYTHONPATH=/root/.local/lib/python.x.

Remove the --user would install the lib under /usr/local/lib, which works directly.